### PR TITLE
Restore compatibility with Rust 1.56

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -234,7 +234,12 @@ where
     let b = b.into_iter();
     (1..min(a.len(), b.len()))
         .rev()
-        .find(|&n| iter::zip(&a[a.len() - n..], b.clone()).all(|(x, y)| x == y.borrow()))
+        .find(|&n| {
+            a[a.len() - n..]
+                .iter()
+                .zip(b.clone())
+                .all(|(x, y)| x == y.borrow())
+        })
         .unwrap_or(0)
 }
 


### PR DESCRIPTION
Rust 1.56 is the first version with support for the 2021 edition. Maintaining support for this version gives people an easy target when determining the oldest compiler they can use.

Textwrap tries to stay compatible with the same Rust version, and this is where I first saw that the [RSRV had increased to 1.59][1].

[1]: https://github.com/mgeisler/textwrap/issues/472