### PR TITLE
Created a `linebreaks_iter()` variant of `linebreaks` 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,24 @@ pub enum BreakOpportunity {
 /// assert!(linebreaks("Hello world!").eq(vec![(6, Allowed), (12, Mandatory)]));
 /// ```
 pub fn linebreaks(s: &str) -> impl Iterator<Item = (usize, BreakOpportunity)> + Clone + '_ {
+    linebreaks_iter(s.char_indices(), s.len())
+}
+
+/// Returns an iterator over line breaks opportunities in the specified input iterator
+///
+/// This is identical to `linebreaks()` but provides the ability to find line breaks
+/// across any iterable set of characters.  Indexes are also factored out
+pub fn linebreaks_iter<'a, N>(
+    iter: impl Iterator<Item = (N, char)> + Clone + 'a,
+    final_idx: N,
+) -> impl Iterator<Item = (N, BreakOpportunity)> + Clone + 'a
+where
+    N: Clone + 'a,
+{
     use BreakOpportunity::{Allowed, Mandatory};
 
-    s.char_indices()
-        .map(|(i, c)| (i, break_property(c as u32) as u8))
-        .chain(once((s.len(), eot)))
+    iter.map(|(i, c)| (i, break_property(c as u32) as u8))
+        .chain(once((final_idx, eot)))
         .scan((sot, false), |state, (i, cls)| {
             // ZWJ is handled outside the table to reduce its size
             let val = PAIR_TABLE[state.0 as usize][cls as usize];


### PR DESCRIPTION
`linebreaks` has a very simple interface - it takes a `&str` and returns an iterator returning break opportunities tagged by positions.  This change introduces a `linebreaks_iter()` variant that instead of taking a `&str`:
- Takes an iterator passing in `char` and arbitrary indexes that do not necessarily have to be `usize`
- A `final_idx` parameter containing the final index.

The original `linebreaks()` function can now easily be implemented in terms of `linebreaks_iter()`:
````
pub fn linebreaks(s: &str) -> impl Iterator<Item = (usize, BreakOpportunity)> + Clone + '_ {
    linebreaks_iter(s.char_indices(), s.len())
}
````

This allows the core algorithm to be decoupled from the representation of the string, allowing text to be passed in alternative formats (e.g. - UTF-16 or UTF-8) or possibly a complex data structure where everything is not conveniently a singular string.